### PR TITLE
Rename `tests` config to `data_tests`

### DIFF
--- a/models/base/jaffle_shop/_jaffle_shop_models.yml
+++ b/models/base/jaffle_shop/_jaffle_shop_models.yml
@@ -6,7 +6,7 @@ models:
       materialized: view
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -15,11 +15,11 @@ models:
       materialized: view
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - completed
@@ -28,7 +28,7 @@ models:
                 - placed
                 - return_pending
       - name: customer_id
-        tests:
+        data_tests:
           - relationships:
               field: customer_id
               to: ref('base_jaffle_shop_customers')

--- a/models/base/jaffle_shop/_jaffle_shop_sources.yml
+++ b/models/base/jaffle_shop/_jaffle_shop_sources.yml
@@ -8,7 +8,7 @@ sources:
       - name: customers
         columns:
           - name: id
-            tests:
+            data_tests:
               - unique
               - not_null
       - name: orders
@@ -22,11 +22,11 @@ sources:
             period: hour
         columns:
           - name: id
-            tests:
+            data_tests:
               - unique
               - not_null
           - name: status
-            tests:
+            data_tests:
               - accepted_values:
                   values:
                     - completed


### PR DESCRIPTION
Address the following warning
```
[WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
```


> Data tests were historically called "tests" in dbt as the only form of testing available. With the introduction of unit tests in v1.8, the key was renamed from tests: to data_tests:.